### PR TITLE
Support filtering results by depth

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,5 +35,7 @@ fn build_walk_parallel(flags: &Flags) -> WalkParallel {
         builder.hidden(false);
     }
 
+    builder.max_depth(flags.depth);
+
     builder.threads(20).build_parallel()
 }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -20,4 +20,8 @@ pub struct Flags {
 
     #[structopt(short = "i", long)]
     pub case_insensitive: bool,
+
+    #[structopt(short, long)]
+    /// The maximum directory depth when looking for matches
+    pub depth: Option<usize>,
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -44,6 +44,15 @@ fn test_all() {
     assert!(run_fnd(vec!["-a"]).contains("./target/debug"));
 }
 
+#[test]
+fn test_max_depth() {
+    assert!(run_fnd(vec![".rs", "-d", "3"]).contains("./src/cli.rs"));
+    assert!(run_fnd(vec![".rs", "-d", "2"]).contains("./src/cli.rs"));
+    assert!(run_fnd(vec!["README.md", "-d", "1"]).contains("./README.md"));
+
+    assert!(!run_fnd(vec![".rs", "-d", "1"]).contains("./src/cli.rs"));
+}
+
 fn run_fnd(args: Vec<&str>) -> String {
     let mut cmd = Command::cargo_bin("fnd").expect("fnd should exist");
     for arg in args {


### PR DESCRIPTION
What?
=====

This introduces a new flag allowing for setting max depth for directory
traversal. This can help find a much smaller set of matches to speed up
results and match accuracy.